### PR TITLE
Add registration view

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,7 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
+    kgio (2.11.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -271,6 +272,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
+    raindrops (0.19.0)
     rake (12.3.2)
     ransack (2.1.1)
       actionpack (>= 5.0)
@@ -353,6 +355,9 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
+    unicorn (5.4.1)
+      kgio (~> 2.6)
+      raindrops (~> 0.7)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)
@@ -411,6 +416,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
+  unicorn
   web-console (>= 3.3.0)
 
 RUBY VERSION

--- a/app/assets/javascripts/registrations.coffee
+++ b/app/assets/javascripts/registrations.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/_login.scss
+++ b/app/assets/stylesheets/_login.scss
@@ -1,0 +1,134 @@
+.main-content__login{
+  display: block;
+  margin: 0;
+  padding: 0;
+
+  &-all{
+      width: 456px;
+      background: #fff;
+      margin: 0 auto;
+
+    &-no_account{
+      padding: 40px 64px;
+      text-align: center;;
+
+      p{
+        font-size: 14px;
+        margin: 0;
+      }
+
+      .link-signin{
+        display: block;
+        margin: 5px;
+        border: 1px solid #0099e8;
+        background: #0099e8;
+        color: #fff;
+        line-height: 40px;
+        text-decoration: none;
+      }
+  }
+
+    &-login{
+        padding: 32px 64px;
+        border-top: 1px solid #eee;
+
+      button.facebook-login{
+          background-color: #385185;
+          color: #fff;
+          display: block;
+          width: 100%;
+          font-size: 14px;
+          line-height: 48px;
+          border: 1px solid #f5f5f5;
+          text-align: center;
+
+        i.fab.fa-facebook{
+            display: inline-block;
+            font-size:130%;
+            margin: 15px 0 15px 5px;
+        }
+      }
+
+      button.google-login{
+            margin: 16px 0 0;
+            background-color:white;
+            display: block;
+            width: 100%;
+            line-height: 48px;
+            font-size:14px;
+            border: 1px solid;
+            text-align: center;
+
+        i.fab.fa-google{
+            display: inline-block;
+            font-size:130%;
+            margin: 15px 0 15px 5px;
+        }
+      }
+    }
+
+
+    form{
+      padding: 0;
+      margin: 0;
+
+      .form-login{
+        padding: 24px 64px 32px;
+        border: 0;
+
+        &-email{
+          margin: 0;
+
+          input.login-email{
+            width: 100%;
+            height: 44px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            background: #fff;
+            font-size: 16px;
+            padding: 0 16px ;
+            box-sizing: border-box;
+          }
+        }
+
+        &-password{
+          margin: 24px 0 0;
+
+          input.login-password{
+            width: 100%;
+            height: 44px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            background: #fff;
+            font-size: 16px;
+            padding: 0 16px ;
+            box-sizing: border-box;
+          }
+        }
+
+        &-no-robot{
+          margin: 24px 0 0;
+        }
+
+        button.login-submit{
+          margin: 24px 0 0;
+          border: 1px solid #ea352d;
+          background: #ea352d;
+          color: #fff;
+          display: block;
+          width: 100%;
+          line-height: 48px;
+          font-size: 14px;
+          text-align: center;
+        }
+      }
+    }
+
+    .forget-password{
+      display: block;
+      margin: 40px 0 0;
+      color: #0099e8;
+      text-decoration: none;
+    }
+  }
+}

--- a/app/assets/stylesheets/_registration-footer.scss
+++ b/app/assets/stylesheets/_registration-footer.scss
@@ -1,0 +1,70 @@
+.main-content__footer{
+    width:456px;
+    height: 220px;
+    margin: 0 auto;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
+    padding: 40px 0;
+    text-align: center;
+
+    &-text-box{
+      padding:0;
+      margin: 0;
+
+      .list-privacy-policy{
+        margin:0;
+        display: inline-block;
+        font-size: 12px;
+
+        .privacy{
+          display: block;
+          color: #333;
+          text-decoration: none;
+        }
+      }
+
+      .list-agreement{
+        display: inline-block;
+        margin: 0 0 0 16px;
+        font-size: 12px;
+
+        .agreement{
+          display: block;
+          color: #333;
+          text-decoration: none;
+        }
+      }
+
+      .list-tokutei{
+        display: inline-block;
+        margin: 0 0 0 16px;
+        font-size: 12px;
+
+        .tokutei{
+          display: block;
+          color: #333;
+          text-decoration: none;
+        }
+      }
+    }
+
+    .mercari-logo{
+      display: block;
+      color: #333;
+      width: 80px;
+      height: 65px;
+      margin: 40px 190px 0;
+      text-decoration: none;
+      .mercari-logo-footer{
+        height:65px;
+        width: 80px;
+      }
+    }
+    .mercari--under-logo{
+      margin: 10px 0 0;
+      font-size: 12px;
+      padding: 0;
+    }
+  }

--- a/app/assets/stylesheets/_registration-footer.scss
+++ b/app/assets/stylesheets/_registration-footer.scss
@@ -9,11 +9,11 @@
     padding: 40px 0;
     text-align: center;
 
-    &-text-box{
+    &-list{
       padding:0;
       margin: 0;
 
-      .list-privacy-policy{
+      &-privacy-policy{
         margin:0;
         display: inline-block;
         font-size: 12px;
@@ -25,7 +25,7 @@
         }
       }
 
-      .list-agreement{
+      &-agreement{
         display: inline-block;
         margin: 0 0 0 16px;
         font-size: 12px;
@@ -37,7 +37,7 @@
         }
       }
 
-      .list-tokutei{
+      &-tokutei{
         display: inline-block;
         margin: 0 0 0 16px;
         font-size: 12px;

--- a/app/assets/stylesheets/_registration-header.scss
+++ b/app/assets/stylesheets/_registration-header.scss
@@ -1,0 +1,15 @@
+.main-content__header{
+  height: 128px;
+  text-align: center;
+  padding: 0 ;
+  background-color: #f5f5f5;
+
+  h1.header-title{
+    margin-top: 0;
+  }
+  .mercari-header-logo{
+    width: 185px;
+    height: 49px;
+    margin: 40px;
+    }
+  }

--- a/app/assets/stylesheets/_registration.scss
+++ b/app/assets/stylesheets/_registration.scss
@@ -1,0 +1,89 @@
+.main-content{
+  background-color: #f5f5f5;
+
+  &__signup{
+    display: block;;
+    margin: 0;
+
+    &-content{
+      width: 700px;
+      margin: 0 auto;
+      background-color: white;
+
+      &-head{
+        padding: 32px 16px;
+        font-size: 22px;
+        text-align: center;
+        font-weight: bold;
+
+      }
+
+      &-main{
+        padding: 64px;
+        border-top: 1px solid #f5f5f5;
+
+        &-content{
+          width: 320px;
+          height: 182px;
+          margin: 0 auto;
+
+          button.e-mail{
+            display: block;
+            position: relative;
+            background-color: #eee;
+            color: #000;
+            line-height: 48px;
+            width: 100%;
+            line-size: 14px;
+            border: 1px solid #f5f5f5;
+            text-align: center;
+            text-decoration: none;
+
+            i.fa.fa-envelope{
+              position: absolute;
+              left: 16px;
+              color:#ccc;
+              font-size: 16px;
+              margin: 15px 0 15px 0;
+            }
+          }
+
+          button.facebook-login{
+            margin: 16px 0 0;
+            background-color: #385185;
+            color: #fff;
+            display: block;
+            width: 100%;
+            font-size: 14px;
+            line-height: 48px;
+            border: 1px solid #f5f5f5;
+            text-align: center;
+
+            i.fab.fa-facebook{
+              display: inline-block;
+              font-size:130%;
+              margin: 15px 0 15px 5px;
+            }
+          }
+
+          button.google-login{
+            margin: 16px 0 0;
+            background-color:white;
+            display: block;
+            width: 100%;
+            line-height: 48px;
+            font-size:14px;
+            border: 1px solid;
+            text-align: center;
+
+            i.fab.fa-google{
+              display: inline-block;
+              font-size: 130%;
+              margin: 15px 0 15px 5px;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/_registration.scss
+++ b/app/assets/stylesheets/_registration.scss
@@ -48,7 +48,7 @@
             }
           }
 
-          button.facebook-login{
+          button.facebook-regist{
             margin: 16px 0 0;
             background-color: #385185;
             color: #fff;
@@ -66,7 +66,7 @@
             }
           }
 
-          button.google-login{
+          button.google-regist{
             margin: 16px 0 0;
             background-color:white;
             display: block;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,3 +7,4 @@
 @import "registration";
 @import "registration-header";
 @import "registration-footer";
+@import "login"

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,3 +3,4 @@
 @import "./items";
 @import "./footer";
 @import "./mixin";
+@import "font-awesome";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,3 +4,6 @@
 @import "./footer";
 @import "./mixin";
 @import "font-awesome";
+@import "registration";
+@import "registration-header";
+@import "registration-footer";

--- a/app/assets/stylesheets/registrations.scss
+++ b/app/assets/stylesheets/registrations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the registrations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,7 @@
+class RegistrationsController < ApplicationController
+  def index
+  end
+
+  def new
+  end
+end

--- a/app/helpers/registrations_helper.rb
+++ b/app/helpers/registrations_helper.rb
@@ -1,0 +1,2 @@
+module RegistrationsHelper
+end

--- a/app/views/registrations/_registration-footer.html.haml
+++ b/app/views/registrations/_registration-footer.html.haml
@@ -1,10 +1,10 @@
 .main-content__footer
-  .main-content__footer-text-box
-    .list-privacy-policy
+  .main-content__footer-list
+    .main-content__footer-list-privacy-policy
       = link_to 'プライバシーポリシー','https://www.mercari.com/jp/privacy/',class: 'privacy'
-    .list-agreement
+    .main-content__footer-list-agreement
       = link_to 'メルカリ利用規約','https://www.mercari.com/jp/tos/',class: 'agreement'
-    .list-tokutei
+    .main-content__footer-list-tokutei
       = link_to '特定商取引に関する表記','https://www.mercari.com/jp/tokutei/',class:'tokutei'
   .mercari-footer
     %img.mercari-logo{:src => "https://www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?128691313"}

--- a/app/views/registrations/_registration-footer.html.haml
+++ b/app/views/registrations/_registration-footer.html.haml
@@ -1,0 +1,11 @@
+.main-content__footer
+  .main-content__footer-text-box
+    .list-privacy-policy
+      = link_to 'プライバシーポリシー','https://www.mercari.com/jp/privacy/',class: 'privacy'
+    .list-agreement
+      = link_to 'メルカリ利用規約','https://www.mercari.com/jp/tos/',class: 'agreement'
+    .list-tokutei
+      = link_to '特定商取引に関する表記','https://www.mercari.com/jp/tokutei/',class:'tokutei'
+  .mercari-footer
+    %img.mercari-logo{:src => "https://www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?128691313"}
+  .mercari--under-logo © 2019 Mercari

--- a/app/views/registrations/_registration-header.html.haml
+++ b/app/views/registrations/_registration-header.html.haml
@@ -1,0 +1,3 @@
+.main-content__header
+  %h1.header-title
+    %img.mercari-header-logo{:src => "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?415487646"}

--- a/app/views/registrations/index.html.haml
+++ b/app/views/registrations/index.html.haml
@@ -9,11 +9,11 @@
           %button.e-mail
             %i.fa.fa-envelope
             メールアドレスで登録
-          %button.facebook-login
+          %button.facebook-regist
             %i.fab.fa-facebook.fa-pull-left
             Facebookで登録
             = link_to ''
-          %button.google-login
+          %button.google-regist
             %i.fab.fa-google.fa-pull-left
             Googleで登録
             = link_to ''

--- a/app/views/registrations/index.html.haml
+++ b/app/views/registrations/index.html.haml
@@ -1,0 +1,22 @@
+.main-content
+  = render 'registration-header'
+
+  .main-content__signup
+    .main-content__signup-content
+      .main-content__signup-content-head 新規会員登録
+      .main-content__signup-content-main
+        .main-content__signup-content-main-content
+          %button.e-mail
+            %i.fa.fa-envelope
+            メールアドレスで登録
+          %button.facebook-login
+            %i.fab.fa-facebook.fa-pull-left
+            Facebookで登録
+            = link_to ''
+          %button.google-login
+            %i.fab.fa-google.fa-pull-left
+            Googleで登録
+            = link_to ''
+
+
+  = render 'registration-footer'

--- a/app/views/registrations/new.html.haml
+++ b/app/views/registrations/new.html.haml
@@ -1,0 +1,27 @@
+.main-content
+  = render 'registration-header'
+
+  .main-content__login
+    .main-content__login-all
+      .main-content__login-all-no_account
+        %p アカウントをお持ちでない方はこちら
+        = link_to '新規会員登録', new_user_registration_path,class: 'link-signin'
+      .main-content__login-all-login
+        %button.facebook-login
+          %i.fab.fa-facebook.fa-pull-left
+          Facebookでログイン
+        %button.google-login
+          %i.fab.fa-google.fa-pull-left
+          Googleでログイン
+      %form{:action => "https://www.mercari.com/jp/login/", :method => ""}
+        .form-login
+          .form-login-email
+            %input.login-email{:name => "email", :placeholder => "メールアドレス", :type => "email", :value => ""}
+          .form-login-password
+            %input.login-password{:name => "password", :placeholder => "パスワード", :type => "password", :value => ""}
+          .form-login-no-robot
+            recaptcha_tags
+          %button.login-submit{:type => "submit"} ログイン
+          =link_to 'パスワードをお忘れの方','https://www.mercari.com/jp/password/reset/start/',class: 'forget-password'
+
+  = render 'registration-footer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,6 @@ Rails.application.routes.draw do
     resources :users, only: :index
   end
 
-
+  resources :registrations,only:[:index,:new]
 
 end


### PR DESCRIPTION
# WHAT
ログイン画面と登録画面の実装
rechptcha_tagsに関してはデプロイ終了後にて実装予定。
loginとregistrationを明確にした。
registration-controllerにindexとnewアクションを仮置きした。
# WHY
同内容のボタンではないため、登録とログインを明確化させるため。
また、recaptchに関してはマージンのみを先に設定し、どこに導入するかのみを決めた。
デプロイ作業が完了していないため、デプロイ作業完了後にrecaptchaを導入予定。

<img width="1698" alt="2019-03-03 19 57 51" src="https://user-images.githubusercontent.com/46644992/53694239-3f4d0100-3def-11e9-92c3-f59c236ff7df.png">
<img width="1742" alt="2019-03-03 19 58 18" src="https://user-images.githubusercontent.com/46644992/53694243-407e2e00-3def-11e9-97e7-72bcdbd4cd2c.png">
