### PR TITLE
Create Fucntion of omniouth Login with Google and Facebook(Google・Facebook認証でのログイン機能を実装しました。)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+/.envrc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,7 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
+    kgio (2.11.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -271,6 +272,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
+    raindrops (0.19.0)
     rake (12.3.2)
     ransack (2.1.1)
       actionpack (>= 5.0)
@@ -353,6 +355,9 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
+    unicorn (5.4.1)
+      kgio (~> 2.6)
+      raindrops (~> 0.7)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)
@@ -411,6 +416,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
+  unicorn
   web-console (>= 3.3.0)
 
 RUBY VERSION

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -4,9 +4,25 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # You should configure your model like this:
   # devise :omniauthable, omniauth_providers: [:twitter]
 
+
   # You should also create an action method in this controller like this:
   # def twitter
   # end
+
+  def google_oauth2
+    callback_for(:google)
+  end
+
+  # common callback method
+  def callback_for(provider)
+    @user = User.from_omniauth(request.env["omniauth.auth"])
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication #this will throw if @user is not activated
+    else
+      redirect_to new_user_registration_url, notice: "認証に失敗しました"
+    end
+  end
+
 
   # More info at:
   # https://github.com/plataformatec/devise#omniauth

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -5,9 +5,9 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # devise :omniauthable, omniauth_providers: [:twitter]
 
 
-  # You should also create an action method in this controller like this:
-  # def twitter
-  # end
+  def facebook
+    callback_for(:facebook)
+  end
 
   def google_oauth2
     callback_for(:google)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,13 +1,18 @@
 class User < ApplicationRecord
+
   has_one :profile
   accepts_nested_attributes_for :profile
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable,
+         :omniauthable, omniauth_providers: [:google_oauth2]
 
-
-
-
+  def self.from_omniauth(auth)
+    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+      user.email = auth.info.email
+      user.password = Devise.friendly_token[0,20]
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :omniauthable, omniauth_providers: [:google_oauth2]
+         :omniauthable, omniauth_providers: %i(google_oauth2 facebook)
 
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -5,3 +5,4 @@
 = link_to 'ログアウト', destroy_user_session_path, method: :delete
 = link_to '新規登録', new_user_registration_path
 = link_to 'ログイン', new_user_session_path
+= link_to "Sign in with Google",  user_google_oauth2_omniauth_authorize_path

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -5,4 +5,5 @@
 = link_to 'ログアウト', destroy_user_session_path, method: :delete
 = link_to '新規登録', new_user_registration_path
 = link_to 'ログイン', new_user_session_path
-= link_to "Sign in with Google",  user_google_oauth2_omniauth_authorize_path
+= link_to "Sign in with Google", user_google_oauth2_omniauth_authorize_path
+= link_to "Sign in with Facebook", user_facebook_omniauth_authorize_path

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -3,6 +3,12 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+  require 'devise/orm/active_record'
+  config.omniauth :google_oauth2,
+  ENV['GOOGLE_CLIENT_ID'],
+  ENV['GOOGLE_CLIENT_SECRET'],
+  scope: 'email'
+
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -3,11 +3,15 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
-  require 'devise/orm/active_record'
   config.omniauth :google_oauth2,
   ENV['GOOGLE_CLIENT_ID'],
   ENV['GOOGLE_CLIENT_SECRET'],
   scope: 'email'
+  config.omniauth :facebook,
+  ENV['FACEBOOK_KEY'],
+  ENV['FACEBOOK_SECRET'],
+  scope: 'email',
+  info_fields: 'email'
 
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,8 @@ Rails.application.routes.draw do
 
   resources :items, only: %i(index show)
   root 'items#index'
-  devise_for :users, :controllers => { :registrations => 'users/registrations' }
-
-
+  devise_for :users, controllers: { registrations: 'users/registrations',
+                                    omniauth_callbacks: 'users/omniauth_callbacks' }
 
   resources :profiles, only: :index
 

--- a/db/migrate/20190304062238_add_omniauth_to_users.rb
+++ b/db/migrate/20190304062238_add_omniauth_to_users.rb
@@ -1,0 +1,6 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_27_075656) do
+ActiveRecord::Schema.define(version: 2019_03_04_062238) do
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -53,6 +53,8 @@ ActiveRecord::Schema.define(version: 2019_02_27_075656) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "provider"
+    t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# WHAT

Googleアカウント、Facebookアカウントでのログイン処理の実装を行いました。
アカウントのEmail情報に基づいてユーザー登録が完了します。
Omniauthの結合テストの記述については、他に実装しなければいけないものもある都合上、別タスクとして切り出して行います。

## Userテーブルに追加したカラムについて

providerカラムと、uidカラムをstring型で追加しました。


## 遷移について

- /users/auth/google_oauth2または/users/auth/facebookにGETでリクエストを送る。

- users/omniauthコントローラーで受け取り、各プロバイダに応じたコールバックメソッド(callback_for(provider))を呼ぶ。

- 登録済みならそのユーザー情報を返し、未登録であれば各プロバイダから受け取ったEmail情報と、Deviseの乱数により作成した20桁のランダムパスワードを付与し、ユーザー登録を完了させる。

よろしくお願いいたします！
